### PR TITLE
Perform migrations in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN mkdir tmp && \
     chown 1000:1000 tmp
 
 EXPOSE 8080
-CMD ["bundle", "exec", "unicorn", "-p", "8080", "-c", "./config/unicorn.rb"]
+CMD ["docker-start.sh"]

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+bundle exec rails db:migrate
+bundle exec unicorn -p 8080 -c ./config/unicorn.rb


### PR DESCRIPTION
Decided to go with start script approach (as opposed to init container) for 2 reasons:
- Support non-k8s workflows (such as local development) better
- Prevents weird issues where the versions of the rails container and init container become mismatched

This should probably be investigated in full and moved to an init container if we end up needing a separate jobs container.

Fixes #133 